### PR TITLE
point panelPomp to panelPomp-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,11 @@
 
 ### an *R* package for inference on panel partially observed Markov processes
 
-[![Project Status: Active -- The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![CRAN Status](https://www.r-pkg.org/badges/version/panelPomp)](https://cran.r-project.org/package=panelPomp)
-[![Last CRAN release date](https://www.r-pkg.org/badges/last-release/panelPomp)](https://cran.r-project.org/package=panelPomp)
-[![R-CMD-check](https://github.com/cbreto/panelPomp/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/cbreto/panelPomp/actions/workflows/r-cmd-check.yml) [![binary-build](https://github.com/cbreto/panelPomp/actions/workflows/binary-build.yml/badge.svg)](https://github.com/cbreto/panelPomp/actions/workflows/binary-build.yml) [![test-coverage](https://github.com/cbreto/panelPomp/actions/workflows/test-coverage.yml/badge.svg)](https://github.com/cbreto/panelPomp/actions/workflows/test-coverage.yml) [![codecov](https://codecov.io/gh/cbreto/panelPomp/branch/master/graph/badge.svg?token=1vT9TJfHGP)](https://codecov.io/gh/cbreto/panelPomp)
+[![Project Status: Active -- The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active) [![CRAN Status](https://www.r-pkg.org/badges/version/panelPomp)](https://cran.r-project.org/package=panelPomp) [![Last CRAN release date](https://www.r-pkg.org/badges/last-release/panelPomp)](https://cran.r-project.org/package=panelPomp) [![R-CMD-check](https://github.com/cbreto/panelPomp/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/panelPomp-org/panelPomp/actions/workflows/r-cmd-check.yml) [![binary-build](https://github.com/panelPomp-org/panelPomp/actions/workflows/binary-build.yml/badge.svg)](https://github.com/panelPomp-org/panelPomp/actions/workflows/binary-build.yml) [![test-coverage](https://github.com/panelPomp-org/panelPomp/actions/workflows/test-coverage.yml/badge.svg)](https://github.com/panelPomp-org/panelPomp/actions/workflows/test-coverage.yml)
 
 This package allows performing data analysis based on panel partially-observed Markov process (PanelPOMP) models. To implement such models, simulate them and fit them to panel data, 'panelPomp' extends some of the facilities provided for time series data by the 'pomp' package. Implemented methods include filtering (panel particle filtering) and maximum likelihood estimation (Panel Iterated Filtering) as proposed in Bretó, Ionides and King (2020) "Panel Data Analysis via Mechanistic Models" [\<doi:10.1080/01621459.2019.1604367\>](https://doi.org/10.1080/01621459.2019.1604367).
 
-The latest version of the package can be installed from this GitHub source using `devtools::install_github('cbreto/panelPomp')`
+The latest version of the package can be installed from this GitHub source using `devtools::install_github('panelPomp-org/panelPomp')`
 
 Installing the current CRAN version is also possible using `install.packages("panelPomp")`
 


### PR DESCRIPTION
Guys-- I swapped cbreto for panelPomp-org in the badge urls in cbreto/panelPomp/README.md, so I've pushed the same updates to panelPomp-org as well. This simple swap doesn't seem to work for the Codecov coverage percentage badge (something that isn't that bad, since github's test-coverage badge works).

This issue with Codecov might resolve itself if, once actions start coming from panelPomp-org/panelPomp, something triggers Codecov to see panelPomp-org. Right now, I can point Codecov's badge at Jesse's fork (jeswheel/panelPomp:master) but not at panelPomp-org/panelPomp:master (Codecov doesn't find it).

The problem may also be related to the (I think) need to include a token in the badge url.

PS: I only had to do the swap in cbreto/panelPomp/README.md; the swap doesn't seem to have been done in all the files in the website repo (panelPomp-org.github.io) which still seem to point to cbreto/panelPomp.