### PR TITLE
Fixed minor bug with profile-design

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: panelPomp
 Type: Package
 Title: Inference for Panel Partially Observed Markov Processes
-Version: 1.7.0.0
+Version: 1.7.0.1
 Authors@R: c(person(given="Carles",family="Breto",role="aut",email="carles.breto@uv.es",comment=c(ORCID="0000-0003-4695-4902")),
 	person(given=c("Edward","L."),family="Ionides",role="aut",comment=c(ORCID="0000-0002-4190-0174")),
 	person(given=c("Aaron","A."),family="King",role="aut",comment=c(ORCID="0000-0001-6159-3207")),
@@ -14,7 +14,6 @@ Depends:
     pomp(>= 4.5.2)
 Imports:
     methods
-RoxygenNote: 7.3.2
 Encoding: UTF-8
 Collate: 
     'panelPomp-package.R'
@@ -47,3 +46,4 @@ Suggests:
     bookdown
 VignetteBuilder: knitr
 LazyData: true
+Config/roxygen2/version: 8.0.0

--- a/R/panel_designs.R
+++ b/R/panel_designs.R
@@ -72,28 +72,40 @@ runif_panel_design <- function (
     if (missing(specific_names) | missing(unit_names))
       stop(wQuotes(ep,"If used, both ''specific_names'' and ''unit_names'' must be provided","."),call.=FALSE)
 
-    if (any(!specific_names %in% lnames))
-      stop(wQuotes(ep,"No bounds were given for some parameters in ''specific_names''","."),call.=FALSE)
+    if (any(!specific_names %in% lnames)) {
+      missing_sp <- specific_names[!specific_names %in% lnames]
+      sp_names_unit <- paste0(missing_sp, '[', rep(unit_names, length(missing_sp)),']')
+      if (any(!sp_names_unit %in% lnames)) {
+        stop(wQuotes(ep,"No bounds were given for some parameters in ''specific_names''","."),call.=FALSE)
+      }
+
+
+    }
 
     lwr_tmp <- lower[!lnames %in% specific_names]
     upr_tmp <- upper[!lnames %in% specific_names]
     upr_tmp <- upr_tmp[names(lwr_tmp)]
 
-    lwr_spec <- rep(
-      lower[lnames %in% specific_names], each = length(unit_names)
-    )
+    if (any(lnames %in% specific_names)) {
+      lwr_spec <- rep(
+        lower[lnames %in% specific_names], each = length(unit_names)
+      )
 
-    unit_labs <- paste0("[", rep(unit_names, length(unique(names(lwr_spec)))), "]")
-    names(lwr_spec) <- paste0(names(lwr_spec), unit_labs)
+      unit_labs <- paste0("[", rep(unit_names, length(unique(names(lwr_spec)))), "]")
+      names(lwr_spec) <- paste0(names(lwr_spec), unit_labs)
 
-    upr_spec <- rep(
-      upper[lnames %in% specific_names], each = length(unit_names)
-    )
+      upr_spec <- rep(
+        upper[lnames %in% specific_names], each = length(unit_names)
+      )
 
-    names(upr_spec) <- names(lwr_spec)
+      names(upr_spec) <- names(lwr_spec)
 
-    lower <- c(lwr_tmp, lwr_spec[!names(lwr_spec) %in% names(lwr_tmp)])
-    upper <- c(upr_tmp, upr_spec[!names(lwr_spec) %in% names(lwr_tmp)])
+      lower <- c(lwr_tmp, lwr_spec[!names(lwr_spec) %in% names(lwr_tmp)])
+      upper <- c(upr_tmp, upr_spec[!names(lwr_spec) %in% names(lwr_tmp)])
+    } else {
+      lower <- lwr_tmp
+      upper <- upr_tmp
+    }
 
     lower <- lower[sort(names(lower))]
     upper <- upper[sort(names(upper))]

--- a/man/as.Rd
+++ b/man/as.Rd
@@ -22,7 +22,7 @@ associated parameters, converting the resulting list to a \code{pompList} to
 help the assignment of pomp methods.
 }
 \seealso{
-Other panelPomp methods: 
+Other panelPomp methods:
 \code{\link{panelPomp_methods}}
 }
 \author{

--- a/man/contacts.Rd
+++ b/man/contacts.Rd
@@ -33,10 +33,10 @@ contacts()
 \vittinghoff1999
 }
 \seealso{
-Other panelPomp examples: 
-\code{\link{panelGompertz}()},
-\code{\link{panelMeasles}()},
-\code{\link{panelRandomWalk}()}
+Other panelPomp examples:
+\code{\link[=panelGompertz]{panelGompertz()}},
+\code{\link[=panelMeasles]{panelMeasles()}},
+\code{\link[=panelRandomWalk]{panelRandomWalk()}}
 }
 \author{
 Edward L. Ionides

--- a/man/mif2.Rd
+++ b/man/mif2.Rd
@@ -131,10 +131,10 @@ traces(mmp)
 \pkg{pomp}'s mif2 at \link[pomp]{mif2},
 \link{panel_loglik}
 
-Other panelPomp workhorse functions: 
-\code{\link{panelPomp}},
+Other panelPomp workhorse functions:
+\code{\link[=panelPomp]{panelPomp()}},
 \code{\link{panel_loglik}},
-\code{\link{pfilter}()}
+\code{\link{pfilter}}
 }
 \author{
 Carles \Breto

--- a/man/panelGompertz.Rd
+++ b/man/panelGompertz.Rd
@@ -36,10 +36,10 @@ panelGompertz()
 \king2016
 }
 \seealso{
-Other panelPomp examples: 
-\code{\link{contacts}()},
-\code{\link{panelMeasles}()},
-\code{\link{panelRandomWalk}()}
+Other panelPomp examples:
+\code{\link[=contacts]{contacts()}},
+\code{\link[=panelMeasles]{panelMeasles()}},
+\code{\link[=panelRandomWalk]{panelRandomWalk()}}
 }
 \author{
 Edward L. Ionides, Carles \Breto

--- a/man/panelMeasles.Rd
+++ b/man/panelMeasles.Rd
@@ -53,9 +53,9 @@ panelMeasles(units = "London")
 \He2010
 }
 \seealso{
-Other panelPomp examples: 
-\code{\link{contacts}()},
-\code{\link{panelGompertz}()},
-\code{\link{panelRandomWalk}()}
+Other panelPomp examples:
+\code{\link[=contacts]{contacts()}},
+\code{\link[=panelGompertz]{panelGompertz()}},
+\code{\link[=panelRandomWalk]{panelRandomWalk()}}
 }
 \concept{panelPomp examples}

--- a/man/panelPomp-package.Rd
+++ b/man/panelPomp-package.Rd
@@ -91,6 +91,7 @@ and \code{panelRandomWalk()} functions.
 
 Authors:
 \itemize{
+  \item Jesse Wheeler \email{jeswheel@umich.edu} (\href{https://orcid.org/0000-0003-3941-3884}{ORCID})
   \item Carles Breto \email{carles.breto@uv.es} (\href{https://orcid.org/0000-0003-4695-4902}{ORCID})
   \item Edward L. Ionides (\href{https://orcid.org/0000-0002-4190-0174}{ORCID})
   \item Aaron A. King (\href{https://orcid.org/0000-0001-6159-3207}{ORCID})

--- a/man/panelPomp.Rd
+++ b/man/panelPomp.Rd
@@ -69,10 +69,10 @@ identical(prw, prw2) # TRUE
 \seealso{
 \pkg{pomp}'s constructor at \link[pomp]{pomp}
 
-Other panelPomp workhorse functions: 
-\code{\link{mif2}()},
+Other panelPomp workhorse functions:
+\code{\link{mif2}},
 \code{\link{panel_loglik}},
-\code{\link{pfilter}()}
+\code{\link{pfilter}}
 }
 \author{
 Carles \Breto

--- a/man/panelPomp_methods.Rd
+++ b/man/panelPomp_methods.Rd
@@ -141,8 +141,8 @@ shared(prw) <- c('sigmaY'=2)
 shared(prw)
 }
 \seealso{
-Other panelPomp methods: 
-\code{\link{as}()}
+Other panelPomp methods:
+\code{\link{as}}
 }
 \author{
 Carles \Breto, Aaron A. King, Edward L. Ionides, Jesse Wheeler

--- a/man/panelRandomWalk.Rd
+++ b/man/panelRandomWalk.Rd
@@ -31,10 +31,10 @@ walk model.
 panelRandomWalk()
 }
 \seealso{
-Other panelPomp examples: 
-\code{\link{contacts}()},
-\code{\link{panelGompertz}()},
-\code{\link{panelMeasles}()}
+Other panelPomp examples:
+\code{\link[=contacts]{contacts()}},
+\code{\link[=panelGompertz]{panelGompertz()}},
+\code{\link[=panelMeasles]{panelMeasles()}}
 }
 \author{
 Edward L. Ionides, Carles \Breto

--- a/man/panel_loglik.Rd
+++ b/man/panel_loglik.Rd
@@ -42,10 +42,10 @@ logLik(ulls,repMargin=1,first="aver",aver="logmeanexp")
 logLik(ulls,repMargin=1,first="aggr",aver="mean",se=TRUE)
 }
 \seealso{
-Other panelPomp workhorse functions: 
-\code{\link{mif2}()},
-\code{\link{panelPomp}},
-\code{\link{pfilter}()}
+Other panelPomp workhorse functions:
+\code{\link{mif2}},
+\code{\link[=panelPomp]{panelPomp()}},
+\code{\link{pfilter}}
 }
 \author{
 Carles \Breto

--- a/man/pfilter.Rd
+++ b/man/pfilter.Rd
@@ -114,9 +114,9 @@ unitLogLik(pfrw)
 \seealso{
 \pkg{pomp}'s pfilter at \link[pomp:pfilter]{pfilter}, \link{panel_loglik}
 
-Other panelPomp workhorse functions: 
-\code{\link{mif2}()},
-\code{\link{panelPomp}},
+Other panelPomp workhorse functions:
+\code{\link{mif2}},
+\code{\link[=panelPomp]{panelPomp()}},
 \code{\link{panel_loglik}}
 }
 \author{

--- a/tests/panel_designs.R
+++ b/tests/panel_designs.R
@@ -34,6 +34,20 @@ test(
   c(NSEQ, 6L)
 )
 
+test(
+  {
+    df <- runif_panel_design(
+      lower = c('a[u1]' = 0, 'b' = 10, 'a[u2]' = 0.5),
+      upper = c('a[u1]' = 1, 'b' = 15, 'a[u2]' = 0.75),
+      specific_names = c('a'),
+      unit_names = paste0(rep('u', 2), 1:2),
+      nseq = NSEQ
+    )
+    c(nrow(df), ncol(df))
+  },
+  c(NSEQ, 3L)
+)
+
 err <- wQuotes("Error : in ''runif_panel_design'': upper values should be at least as large as lower ones.\n")
 
 test(

--- a/tests/panel_designs.Rout.save
+++ b/tests/panel_designs.Rout.save
@@ -1,6 +1,6 @@
 
-R version 4.4.1 (2024-06-14) -- "Race for Your Life"
-Copyright (C) 2024 The R Foundation for Statistical Computing
+R version 4.6.1 (2026-06-24) -- "Happy Hop"
+Copyright (C) 2026 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
@@ -52,6 +52,21 @@ Type 'q()' to quit R.
 +     c(nrow(df), ncol(df))
 +   },
 +   c(NSEQ, 6L)
++ )
+[1] TRUE
+> 
+> test(
++   {
++     df <- runif_panel_design(
++       lower = c('a[u1]' = 0, 'b' = 10, 'a[u2]' = 0.5),
++       upper = c('a[u1]' = 1, 'b' = 15, 'a[u2]' = 0.75),
++       specific_names = c('a'),
++       unit_names = paste0(rep('u', 2), 1:2),
++       nseq = NSEQ
++     )
++     c(nrow(df), ncol(df))
++   },
++   c(NSEQ, 3L)
 + )
 [1] TRUE
 > 


### PR DESCRIPTION
Bug occurred if a user specified lower and upper bounds for unit-specific parameters by name for *all* units for a particular parameter class. For instance, the following would throw an error, though it is a reasonable way to specify parameter bounds: 

```
df <- runif_panel_design(
   lower = c('a[u1]' = 0, 'b' = 10, 'a[u2]' = 0.5),
   upper = c('a[u1]' = 1, 'b' = 15, 'a[u2]' = 0.75),
   specific_names = c('a'),
   unit_names = paste0(rep('u', 2), 1:2),
   nseq = NSEQ
)
```